### PR TITLE
Overflow fixes

### DIFF
--- a/nedmalloc.c
+++ b/nedmalloc.c
@@ -2018,8 +2018,12 @@ NEDMALLOCNOALIASATTR NEDMALLOCPTRATTR void * nedpmalloc(nedpool *p, size_t size)
 }
 NEDMALLOCNOALIASATTR NEDMALLOCPTRATTR void * nedpcalloc(nedpool *p, size_t no, size_t size) THROWSPEC
 {
-	unsigned flags=NEDMALLOC_FORCERESERVE(p, 0, no*size);
-	return nedpmalloc2(p, size*no, 0, M2_ZERO_MEMORY|flags);
+	size_t bytes=no*size;
+	/* Avoid multiplication overflow. */
+	if(size && no!=bytes/size)
+		return 0;
+	unsigned flags=NEDMALLOC_FORCERESERVE(p, 0, bytes);
+	return nedpmalloc2(p, bytes, 0, M2_ZERO_MEMORY|flags);
 }
 NEDMALLOCNOALIASATTR NEDMALLOCPTRATTR void * nedprealloc(nedpool *p, void *mem, size_t size) THROWSPEC
 {

--- a/nedmalloc.c
+++ b/nedmalloc.c
@@ -328,7 +328,11 @@ static FORCEINLINE NEDMALLOCNOALIASATTR NEDMALLOCPTRATTR void *CallMalloc(void *
 #if USE_MAGIC_HEADERS
 	size_t _alignment=alignment;
 	size_t *_ret=0;
-	size+=alignment+3*sizeof(size_t);
+	size_t bytes=size+alignment+3*sizeof(size_t);
+	/* Avoid addition overflow. */
+	if(bytes<size)
+		return 0;
+	size=bytes;
 	_alignment=0;
 #endif
 #if USE_ALLOCATOR==0


### PR DESCRIPTION
Hi,

This fixes two integer overflows when using calloc() and malloc(),
respectively, which could lead to buffer overflows.
- `calloc(n, size)`: `n * size` could overflow.

This happened to glibc a few years ago.  

http://cert.uni-stuttgart.de/ticker/advisories/calloc.html
- `malloc(size)`: `size` could overflow after alignment.

This is dangerous if `size` is user-controlled.

```
size = /* read from input */;
p = malloc(size);
if (p) memcpy(p, src, size);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ned14/nedmalloc/6)
<!-- Reviewable:end -->
